### PR TITLE
Format cablegram in Chapter 3 as a telegram

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -23,6 +23,11 @@ footer{
 	font-variant: small-caps;
 }
 
+/* Telegram Styling */
+.telegram{
+	font-variant: all-small-caps;
+}
+
 /* Poetry Styling */
 [epub|type~="z3998:hymn"] p{
 	text-align: initial;

--- a/src/epub/text/chapter-3.xhtml
+++ b/src/epub/text/chapter-3.xhtml
@@ -106,7 +106,7 @@
 			<p>After all, he reflected, it might be that she was in Paris and, if there, it was natural that she would be with Violet Silverstairs. These two items were, therefore, not improbably correct. That view reached, the deduction followed: If they are correct, the other may be. Yet, in that case, he argued, obviously she must think me dead. On the heels of this second deduction an impression trod⁠—the ease and dispatch with which she had become consoled.</p>
 			<p>Enraged at once, angered already by what he had taken for a lie and then infuriated by what he took for truth, the anterior incidents that had this supreme outrage for climax, leaped at him. At the onslaught the primitive passions flared, and it was with the impulse of the homicide that he determined to seek and overwhelm this woman who accepted men and matters with such entire sans-gêne.</p>
 			<p>On the morrow he left for New York. Before going he sent a cablegram to the address which the paper had supplied:</p>
-			<blockquote epub:type="z3998:letter">
+			<blockquote class="telegram" epub:type="z3998:letter">
 				<p>Am just apprised of the studied insult of your engagement to some foreign cad. Leaving for Paris at once.</p>
 			</blockquote>
 			<p>As he signed it, deeply, beneath the breath, he swore. “That will show her,” he added.</p>


### PR DESCRIPTION
I haven't finished reading this yet, but I noticed that this cablegram did not have the new telegram styling, so this PR styles it as a telegram following [SEMoS §7.7.2](https://standardebooks.org/manual/1.8.2/7-high-level-structural-patterns#7.7.2).